### PR TITLE
Added mouse dragging support and active tile preview in toolbar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ gba-tileeditor
 *.elf
 .qmake.stash
 moc_predefs.h
+*.pro.user

--- a/editorwindow.cpp
+++ b/editorwindow.cpp
@@ -52,6 +52,8 @@ void EditorWindow::setup_triggers(Ui_MainWindow* ui) {
     QObject::connect(ui->actionZoom_Out, SIGNAL(triggered()), this, SLOT(on_zoom_out()));
     QObject::connect(ui->actionChange_Properties, SIGNAL(triggered()), this, SLOT(on_change_properties()));
     QObject::connect(ui->actionShow_Grid, SIGNAL(triggered()), this, SLOT(on_grid()));
+
+    activeTileInToolbarAction = ui->toolBar->addAction("");
 }
 
 /* refresh the map area */
@@ -312,6 +314,23 @@ void EditorWindow::palette_click(int x, int y) {
 
     /* set the current tile based on this */
     current_tile = tile;
+    updateTilePreviewIcon();
+}
+
+void EditorWindow::updateTilePreviewIcon() {
+    int tilex = (current_tile * 8) % (tiles.width());
+    int tiley = ((current_tile * 8) / (tiles.width())) * 8;
+
+    QImage image(8, 8, QImage::Format_RGB555);
+
+    for (int i = 0; i < 8; i++) {
+        for (int j = 0; j < 8; j++) {
+            QRgb color = tiles.pixel(tilex + i, tiley + j);
+            image.setPixel(i, j, color);
+        }
+    }
+
+    activeTileInToolbarAction->setIcon(QPixmap::fromImage(image.scaled(32, 32, Qt::KeepAspectRatio)));
 }
 
 /* called when the map is clicked */

--- a/editorwindow.h
+++ b/editorwindow.h
@@ -19,6 +19,8 @@ class EditorWindow : public QMainWindow {
         /* pointer to the main app so we can close it */
         QApplication* app;
 
+        QAction* activeTileInToolbarAction;
+
         /* pointers to the map and palette area */
         QGraphicsScene* map_scene;
         QGraphicsScene* palette_scene;
@@ -56,6 +58,7 @@ class EditorWindow : public QMainWindow {
         /* refreshes the map or palette views */
         void refresh_map();
         void refresh_palette();
+        void updateTilePreviewIcon();
 
     public:
         EditorWindow(QApplication* app);

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -36,7 +36,7 @@
      <x>0</x>
      <y>0</y>
      <width>985</width>
-     <height>18</height>
+     <height>22</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuFile">
@@ -90,6 +90,7 @@
    <addaction name="actionZoom_In"/>
    <addaction name="actionZoom_Out"/>
    <addaction name="actionShow_Grid"/>
+   <addaction name="separator"/>
   </widget>
   <action name="actionNew">
    <property name="text">

--- a/map.cpp
+++ b/map.cpp
@@ -336,7 +336,7 @@ QPixmap Map::get_pixmap(QImage* tile_image, bool grid_mode, QColor grid_color) {
         }
     } 
 
-    /* draw the gird, if needed */
+    /* draw the grid, if needed */
     if (grid_mode) {
 
         /* for each row 7 of a tile */

--- a/mapview.cpp
+++ b/mapview.cpp
@@ -11,7 +11,7 @@
 #include "ui_mainwindow.h"
 #include "ui_newmap.h"
 
-MapView::MapView(QWidget* parent) : QGraphicsView(parent) {
+MapView::MapView(QWidget* parent) : QGraphicsView(parent), dragging(false) {
 
 }
 
@@ -21,8 +21,8 @@ void MapView::set_window(EditorWindow* window) {
 }
 
 /* mouse handlers */
-void MapView::mousePressEvent(QMouseEvent* e) {
-    if (e->button() != Qt::LeftButton) {
+void MapView::mouseMoveEvent(QMouseEvent* e) {
+    if(!dragging) {
         return;
     }
 
@@ -32,5 +32,15 @@ void MapView::mousePressEvent(QMouseEvent* e) {
 
     /* apply the click onto the window - adjusted for scroll */
     window->map_click(e->x() + scroll_x, e->y() + scroll_y);
+}
+
+void MapView::mouseReleaseEvent(QMouseEvent* e) {
+    dragging = false;
+}
+
+void MapView::mousePressEvent(QMouseEvent* e) {
+    if (e->button() == Qt::LeftButton) {
+        dragging = true;
+    }
 }
 

--- a/mapview.cpp
+++ b/mapview.cpp
@@ -25,7 +25,10 @@ void MapView::mouseMoveEvent(QMouseEvent* e) {
     if(!dragging) {
         return;
     }
+    updateMapAt(e);
+}
 
+void MapView::updateMapAt(QMouseEvent* e) {
     /* find the position of our scroll bar */
     int scroll_x = horizontalScrollBar()->value();
     int scroll_y = verticalScrollBar()->value();
@@ -42,5 +45,6 @@ void MapView::mousePressEvent(QMouseEvent* e) {
     if (e->button() == Qt::LeftButton) {
         dragging = true;
     }
+    updateMapAt(e);
 }
 

--- a/mapview.h
+++ b/mapview.h
@@ -15,6 +15,7 @@ class MapView : public QGraphicsView {
     private:
         EditorWindow* window;
         bool dragging;
+        void updateMapAt(QMouseEvent* event);
 
     public:
         MapView(QWidget* parent);

--- a/mapview.h
+++ b/mapview.h
@@ -14,11 +14,14 @@ class MapView : public QGraphicsView {
 
     private:
         EditorWindow* window;
+        bool dragging;
 
     public:
         MapView(QWidget* parent);
         void set_window(EditorWindow* window);
         void mousePressEvent(QMouseEvent* event);
+        void mouseReleaseEvent(QMouseEvent* event);
+        void mouseMoveEvent(QMouseEvent* event);
 };
 
 #endif


### PR DESCRIPTION
Hi Ian,

When you need to create a "big" map, constantly clicking is a chore.
I've added click-and-drag support to quickly build a map.

Also, it was unclear for me which was the active tile, so I added a "preview" icon in the toolbar.

Would you check it out and see if it suits your editor well?
If that is the case, It would be great to create a new release for these enhancements!

Regards,
Wouter