### PR TITLE
provide substitute for qt5-default on more recent ubuntu versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ Installing on Ubuntu Linux:
 5. `make`
 6. Run gba-tileeditor
 7. To install globally, copy gba-tileeditor to /usr/local/bin
+
+If `qt5-default` is not available on your version of Ubuntu [you will need to manually install all its dependencies instead](https://askubuntu.com/questions/1335184/qt5-default-not-in-ubuntu-21-04) using the following command: 
+
+`sudo apt-get install qtbase5-dev qtchooser qt5-qmake qtbase5-dev-tools`
     
 Installing on Windows:
 -------------


### PR DESCRIPTION

`qt5-default` is not available on more recent versions of Ubuntu.
Manually installing its dependencies as indicated in the accepted answer on [this linked StackOverflow post](https://askubuntu.com/questions/1335184/qt5-default-not-in-ubuntu-21-04) worked well on Ubuntu 22.04

Thank you very much for your work, wishing you a happy and prosperous 2023!