### PR TITLE
fix bugs with dragging

### DIFF
--- a/editorwindow.cpp
+++ b/editorwindow.cpp
@@ -32,8 +32,6 @@ EditorWindow::EditorWindow(QApplication* app) {
     just_saved = true;
     zoom_factor = 2;
     filename_valid = false;
-
-
 }
 
 /* set the map and palette areas */
@@ -369,8 +367,11 @@ void EditorWindow::map_click(int x, int y) {
         updateTilePreviewIcon();
     }
     else {
-        map->set_tile(tile, current_tile);
-        refresh_map();
+        if (map->get_tile(tile) != current_tile) {
+            printf("%d\n", tile);
+            map->set_tile(tile, current_tile);
+            refresh_map();
+        }
     }
 }
 

--- a/editorwindow.cpp
+++ b/editorwindow.cpp
@@ -373,6 +373,10 @@ void EditorWindow::map_click(int x, int y) {
     }
 }
 
+void EditorWindow::start_drag() {
+    map->start_drag();
+}
+
 /* called when the user quits from the application */
 void EditorWindow::on_quit() {
     if (!just_saved) {

--- a/editorwindow.cpp
+++ b/editorwindow.cpp
@@ -1,6 +1,7 @@
 /* editorwindow.cpp
  * implementation fle for the main editor window */
 
+#include <cstddef>
 #include <stdio.h>
 #include <QMouseEvent>
 #include <QKeyEvent>
@@ -374,7 +375,9 @@ void EditorWindow::map_click(int x, int y) {
 }
 
 void EditorWindow::start_drag() {
-    map->start_drag();
+    if (map != NULL) {
+        map->start_drag();
+    }
 }
 
 /* called when the user quits from the application */

--- a/editorwindow.cpp
+++ b/editorwindow.cpp
@@ -350,7 +350,7 @@ void EditorWindow::map_click(int x, int y) {
     y /= zoom_factor;
 
     /* if the click is out of bounds, then bail */
-    if (x > (map->get_width() * 8) || y > (map->get_height() * 8)) {
+    if (x >= (map->get_width() * 8) || x < 0 || y > (map->get_height() * 8)) {
         return;
     }
 

--- a/editorwindow.cpp
+++ b/editorwindow.cpp
@@ -368,7 +368,6 @@ void EditorWindow::map_click(int x, int y) {
     }
     else {
         if (map->get_tile(tile) != current_tile) {
-            printf("%d\n", tile);
             map->set_tile(tile, current_tile);
             refresh_map();
         }

--- a/editorwindow.h
+++ b/editorwindow.h
@@ -72,6 +72,7 @@ class EditorWindow : public QMainWindow {
         void setup_triggers(Ui_MainWindow* ui);
         void palette_click(int x, int y);
         void map_click(int x, int y); 
+        void start_drag();
         void closeEvent(QCloseEvent* event);
 
         public slots:

--- a/map.cpp
+++ b/map.cpp
@@ -292,16 +292,18 @@ void Map::write(const std::string& filename) {
     fclose(f);
 }
 
-/* modify the tile */
-void Map::set_tile(int index, int tile_no) {
-    /* save state */
+/* pushes map state to undo stack when drag is started */
+void Map::start_drag() {
     int* temp = new int[width * height];
     for (int i = 0; i < width * height; i++) {
         temp[i] = tiles[i];
     }
-    undo_stack.push(temp);
 
-    /* and make the change */
+    undo_stack.push(temp);
+}
+
+/* modify the tile */
+void Map::set_tile(int index, int tile_no) {
     tiles[index] = tile_no; 
 }
 

--- a/map.h
+++ b/map.h
@@ -37,6 +37,8 @@ class Map {
         void write(const std::string& filename);
         bool read(const std::string& filename);
 
+        void start_drag();
+
         /* set a tile in the map to a new value */
         void set_tile(int index, int tile_no);
         int get_tile(int index);

--- a/mapview.cpp
+++ b/mapview.cpp
@@ -37,6 +37,7 @@ void MapView::updateMapAt(QMouseEvent* e) {
     window->map_click(e->x() + scroll_x, e->y() + scroll_y);
 }
 
+
 void MapView::mouseReleaseEvent(QMouseEvent* e) {
     dragging = false;
 }
@@ -44,6 +45,7 @@ void MapView::mouseReleaseEvent(QMouseEvent* e) {
 void MapView::mousePressEvent(QMouseEvent* e) {
     if (e->button() == Qt::LeftButton) {
         dragging = true;
+        window->start_drag();
     }
     updateMapAt(e);
 }

--- a/mapview.cpp
+++ b/mapview.cpp
@@ -8,6 +8,7 @@
 #include <QFileDialog>
 #include "editorwindow.h"
 #include "newdialog.h"
+#include "qnamespace.h"
 #include "ui_mainwindow.h"
 #include "ui_newmap.h"
 
@@ -39,13 +40,16 @@ void MapView::updateMapAt(QMouseEvent* e) {
 
 
 void MapView::mouseReleaseEvent(QMouseEvent* e) {
-    dragging = false;
+    if (e->button() == Qt::LeftButton) {
+        dragging = false;
+    }
 }
 
 void MapView::mousePressEvent(QMouseEvent* e) {
     if (e->button() == Qt::LeftButton) {
         dragging = true;
         window->start_drag();
+
+        updateMapAt(e);
     }
-    updateMapAt(e);
 }


### PR DESCRIPTION
I've fixed a few bugs relating to dragging. 

**Bounds Checking**
The map click bounds checking was off by 1 pixel. This was particularly noticeable when dragging. 

**Undo** 
Previously, the board state wold be pushed to the undo stack every time a map click was registered. Map clicks would be registered throughout the duration of a drag, regardless of whether or not the mouse was actually on a different tile or not. This resulted in unchanged board states getting pushed to the undo stack. I've made it so that the board state is only saved when the user starts dragging their mouse. This allows the user to undo an entire mouse drag worth of tiles at a time, as opposed to undoing a single pixel at a time at best.

**Check if Left Button is Released**
The "MouseReleaseEvent" triggers when any mouse button is released. This meant that if the user was dragging with their left mouse button, and released their right mouse button, the drag would be stopped, even if the user was still holding down their left button. I've added a check to prevent this behavior.  

**Only Refresh Map if Tiles Change**
Every time a map click was registered, the map would be refreshed, even if them map remained unchanged. I've added a check to make sure that a new tile is actually being placed before a map refresh is triggered. 

This change was an attempt to fix some performance issues that I was experiencing when editing 128x128 tile maps. It looks like it may have provided a marginal improvement to performance, but it doesn't fix the root issue, which I think may have something to do with wayland. 